### PR TITLE
Fix compilation on gcc-mingw-w64 8.3 (debian buster)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export CC=x86_64-w64-mingw32-g++
 NULL_DEV=/dev/null
-CFLAGS=-nostdinc -fno-exceptions -I/usr/x86_64-w64-mingw32/include -I/usr/lib/gcc/x86_64-w64-mingw32/6.3-win32/include -std=c++11 -static -DUNICODE -municode
+CFLAGS=-nostdinc -fno-exceptions -I/usr/x86_64-w64-mingw32/include -I/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/include -I/usr/lib/gcc/x86_64-w64-mingw32/6.3-win32/include -std=c++11 -static -DUNICODE -municode
 
 containerutility.exe: argumentstream.cpp commands.cpp containerutility.cpp identity.cpp version.cpp argumentstream.h commands.h containerutility.h identity.h version.h Makefile
 	@$(CC) $(CFLAGS) -O3 -s -o containerutility.exe argumentstream.cpp commands.cpp containerutility.cpp identity.cpp version.cpp


### PR DESCRIPTION
relates to https://github.com/moby/moby/pull/39880

Debian buster installs gcc-mingw-w64 8.3, causing compilation to fail due to the hard-coded path for includes.

```
In file included from /usr/x86_64-w64-mingw32/include/minwindef.h:163,
                 from /usr/x86_64-w64-mingw32/include/windef.h:8,
                 from /usr/x86_64-w64-mingw32/include/windows.h:69,
                 from containerutility.h:3,
                 from argumentstream.cpp:1:
/usr/x86_64-w64-mingw32/include/winnt.h:1554:11: fatal error: x86intrin.h: No such file or directory
 # include <x86intrin.h>
           ^~~~~~~~~~~~~
compilation terminated.
```

Note that instead of adding a manual path to this list, compilation also succeeds if the `-nostdinc` option is removed (which makes `gcc-mingw-w64` search the standard paths:

```bash
x86_64-w64-mingw32-g++ -print-search-dirs
install: /usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/
programs: =/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/:/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/:/usr/lib/gcc/x86_64-w64-mingw32/:/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/:/usr/lib/gcc/x86_64-w64-mingw32/:/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/../../../../x86_64-w64-mingw32/bin/x86_64-w64-mingw32/8.3-win32/:/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/../../../../x86_64-w64-mingw32/bin/
libraries: =/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/:/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/../../../../x86_64-w64-mingw32/lib/x86_64-w64-mingw32/8.3-win32/:/usr/lib/gcc/x86_64-w64-mingw32/8.3-win32/../../../../x86_64-w64-mingw32/lib/
```

With the `-nostdinc` removed, compilation is successful 
```
x86_64-w64-mingw32-g++ -fno-exceptions -std=c++11 -static -DUNICODE -municode -O3 -s -o containerutility.exe argumentstream.cpp commands.cpp containerutility.cpp identity.cpp version.cpp
echo $?
0
```

I decided to keep the current approach, assuming that specifying these paths, and
explicitly excluding the standard paths was done for a reason. That said, if there
is no specific reason, we might want to opt for the last option, as it is more
flexible and doesn't depend on hard-coded paths (which may change in future
updates).
